### PR TITLE
chore: 升级 @kne/button-group 至 ^0.1.40 (0.5.35)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.34",
+  "version": "0.5.35",
   "files": [
     "build"
   ],
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/kne-union/components-core.git"
   },
   "dependencies": {
-    "@kne/button-group": "^0.1.39",
+    "@kne/button-group": "^0.1.40",
     "@kne/compose": "^0.1.0",
     "@kne/create-deferred": "^0.1.1",
     "@kne/ensure-slash": "^0.1.0",


### PR DESCRIPTION
## Summary
- 将 `@kne/button-group` 从 `^0.1.39` 升级到 `^0.1.40`
- 版本号 `0.5.34` → `0.5.35`

## Test plan
- [ ] 确认依赖安装为 `@kne/button-group@0.1.40`
- [ ] 合并后检查 Publish Npm Package workflow 是否成功

Made with [Cursor](https://cursor.com)