### PR TITLE
chore: 升级 @kne/modules-dev 至 ^2.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.35",
+  "version": "0.5.36",
   "files": [
     "build"
   ],
@@ -107,7 +107,7 @@
   "devDependencies": {
     "@kne/craco": "^7.1.4",
     "@kne/md-doc": "^0.1.24",
-    "@kne/modules-dev": "^2.4.3",
+    "@kne/modules-dev": "^2.4.10",
     "@kne/react-error-boundary": "^0.1.1",
     "antd": "6.0.0",
     "http-proxy-middleware": "^2.0.6",


### PR DESCRIPTION
## Summary
- 将 `@kne/modules-dev` 从 `^2.4.3` 升级到 `^2.4.10`（含生产构建 `concatenateModules: false`，避免 MF 远程包 TDZ）
- 本包 version：`0.5.35` → `0.5.36`

## Test plan
- [ ] 合并后确认 Publish workflow 发布 `@kne-components/components-core@0.5.36`
- [ ] 本地 `npm start` 能正常启动 example

Made with [Cursor](https://cursor.com)