### PR TITLE
chore: 升级 @kne/button-group 至 ^0.1.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.36",
+  "version": "0.5.37",
   "files": [
     "build"
   ],
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/kne-union/components-core.git"
   },
   "dependencies": {
-    "@kne/button-group": "^0.1.40",
+    "@kne/button-group": "^0.1.41",
     "@kne/compose": "^0.1.0",
     "@kne/create-deferred": "^0.1.1",
     "@kne/ensure-slash": "^0.1.0",


### PR DESCRIPTION
## Summary
- 版本 `0.5.36` → `0.5.37`
- 升级 `@kne/button-group` `^0.1.40` → `^0.1.41`，同步 ButtonGroup `place` 容器内九点定位

## Test plan
- [ ] 合并后确认 Publish Npm Package workflow 成功
- [ ] 页头 `buttonOptions` 可传 `place: 'end'` 使按钮居右


Made with [Cursor](https://cursor.com)