### PR TITLE
chore: 升级 @kne/flex-box 至 ^0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.37",
+  "version": "0.5.38",
   "files": [
     "build"
   ],
@@ -25,7 +25,7 @@
     "@kne/compose": "^0.1.0",
     "@kne/create-deferred": "^0.1.1",
     "@kne/ensure-slash": "^0.1.0",
-    "@kne/flex-box": "^0.1.1",
+    "@kne/flex-box": "^0.1.2",
     "@kne/form-info": "^0.1.10",
     "@kne/global-context": "^1.3.2",
     "@kne/info-page": "^0.2.13",


### PR DESCRIPTION
## Summary
- 将 `@kne/flex-box` 从 `^0.1.1` 升到 `^0.1.2`（antd 6 Grid 同一行卡片等高）
- 本包版本 `0.5.37` → `0.5.38`

## Test plan
- [ ] 合并后确认 Publish workflow 发出 `@kne-components/components-core@0.5.38`
- [ ] 远程 `components-core:FlexBox` 同一行卡片等高

Made with [Cursor](https://cursor.com)