### PR TITLE
chore: 升级 @kne/super-select 至 ^0.1.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.38",
+  "version": "0.5.39",
   "files": [
     "build"
   ],
@@ -45,7 +45,7 @@
     "@kne/remote-loader": "^1.4.6",
     "@kne/responsive-utils": "^0.1.15",
     "@kne/scroll-loader": "^0.1.14",
-    "@kne/super-select": "^0.1.46",
+    "@kne/super-select": "^0.1.48",
     "@kne/super-select-plus": "^0.1.3",
     "@kne/table-page": "^0.1.30",
     "@kne/use-click-outside": "^0.2.1",


### PR DESCRIPTION
## Summary
- `@kne/super-select` `^0.1.46` → `^0.1.48`（SelectTableList 搜索按 `pagination.paramsType` 写入请求）
- version: `0.5.38` → `0.5.39`

## Test plan
- [ ] 合并后确认 Publish workflow 发出 `@kne-components/components-core@0.5.39`
- [ ] 业务仓将 `preset.js` 的 `components-core` `defaultVersion` 改为 `0.5.39` 后，技能标签弹窗搜索生效

Made with [Cursor](https://cursor.com)