### PR TITLE
chore: 升级 table-page / scroll-loader (0.5.41)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.40",
+  "version": "0.5.41",
   "files": [
     "build"
   ],
@@ -44,10 +44,10 @@
     "@kne/react-text-escape": "^0.1.4",
     "@kne/remote-loader": "^1.4.6",
     "@kne/responsive-utils": "^0.1.15",
-    "@kne/scroll-loader": "^0.1.14",
+    "@kne/scroll-loader": "^0.1.15",
     "@kne/super-select": "^0.1.50",
     "@kne/super-select-plus": "^0.1.3",
-    "@kne/table-page": "^0.1.30",
+    "@kne/table-page": "^0.1.33",
     "@kne/use-click-outside": "^0.2.1",
     "@kne/use-control-value": "^0.1.9",
     "@kne/use-ref-callback": "^0.1.3",


### PR DESCRIPTION
## Summary
- `@kne/table-page` `^0.1.30` → `^0.1.33`（内含 scroll-loader 0.1.15）
- `@kne/scroll-loader` `^0.1.14` → `^0.1.15`（maxFullCount 仅限制无滚动条自动补载）
- 本包版本 `0.5.40 → 0.5.41`

## Test plan
- [ ] 构建/发布后确认依赖解析到 table-page@0.1.33、scroll-loader@0.1.15
- [ ] 业务端升 `components-core` defaultVersion 后，列表/forceCard 下拉在 totalCount 较大时可加载到全部，不再卡在约第 4 页

Made with [Cursor](https://cursor.com)