### PR TITLE
chore: bump @kne/table-page to ^0.1.34 (0.5.41 → 0.5.42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.41",
+  "version": "0.5.42",
   "files": [
     "build"
   ],
@@ -47,7 +47,7 @@
     "@kne/scroll-loader": "^0.1.15",
     "@kne/super-select": "^0.1.50",
     "@kne/super-select-plus": "^0.1.3",
-    "@kne/table-page": "^0.1.33",
+    "@kne/table-page": "^0.1.34",
     "@kne/use-click-outside": "^0.2.1",
     "@kne/use-control-value": "^0.1.9",
     "@kne/use-ref-callback": "^0.1.3",


### PR DESCRIPTION
## Summary
- Bump `@kne/table-page` `^0.1.33` → `^0.1.34` (includes `@kne/react-sticky-scroller@^0.1.3`)
- Version `0.5.41` → `0.5.42`

Merge order:
1. [react-sticky-scroller#4](https://github.com/kne-union/react-sticky-scroller/pull/4) → `0.1.3`
2. [table-page#32](https://github.com/kne-union/table-page/pull/32) → `0.1.34`
3. This PR → `components-core@0.5.42`

## Test plan
- [ ] Prior two packages published
- [ ] CI install + Publish `0.5.42`
- [ ] Downstream preset `defaultVersion` → `0.5.42`