### PR TITLE
chore: bump @kne/table-page to ^0.1.35 (0.5.42 → 0.5.43)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.42",
+  "version": "0.5.43",
   "files": [
     "build"
   ],
@@ -47,7 +47,7 @@
     "@kne/scroll-loader": "^0.1.15",
     "@kne/super-select": "^0.1.50",
     "@kne/super-select-plus": "^0.1.3",
-    "@kne/table-page": "^0.1.34",
+    "@kne/table-page": "^0.1.35",
     "@kne/use-click-outside": "^0.2.1",
     "@kne/use-control-value": "^0.1.9",
     "@kne/use-ref-callback": "^0.1.3",


### PR DESCRIPTION
## Summary
- Upgrade `@kne/table-page` `^0.1.34` → `^0.1.35` (FilterValueDisplay overflow fix)
- Bump components-core `0.5.42` → `0.5.43`

## Test plan
- [ ] Confirm CI Publish succeeds after merge
- [ ] TablePage with active filters: selected-filter row no longer overflows card edge


Made with [Cursor](https://cursor.com)