### PR TITLE
fix: DatePickerToday 允许覆盖默认日期占位文案

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@kne/react-file": "^0.1.55",
     "@kne/react-file-type": "^1.0.9",
     "@kne/react-filter": "^2.0.6",
-    "@kne/react-form-antd": "^4.1.2",
+    "@kne/react-form-antd": "^4.1.3",
     "@kne/react-form-plus": "^0.1.7",
     "@kne/react-icon": "^0.1.4",
     "@kne/react-intl": "^0.1.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.43",
+  "version": "0.5.44",
   "files": [
     "build"
   ],

--- a/src/components/FormInfo/formModule.js
+++ b/src/components/FormInfo/formModule.js
@@ -156,7 +156,7 @@ export const DatePickerToday = withLocale(({
     return (<ReactDatePickerToday
         {...props}
         label={label}
-        placeholder={[formatMessage({id: "startDate"}), formatMessage({id: "endDate"}),]}
+        placeholder={placeholder || [formatMessage({id: "startDate"}), formatMessage({id: "endDate"}),]}
         soFarText={soFarText || formatMessage({id: "soFarText"})}
     />);
 });


### PR DESCRIPTION
## Summary
- `DatePickerToday` 在 `formModule` 中原先总会用内置 `startDate`/`endDate` 覆盖 `placeholder`，业务传入的英文占位无法生效。
- 改为优先使用外部 `placeholder`，未传入时再回退到组件默认文案。
- 版本：`0.5.43` → `0.5.44`

## Test plan
- [ ] 不传 `placeholder` 时，开始/结束日期仍显示组件默认占位文案
- [ ] 传入 `placeholder={['Start date', 'End date']}` 时展示传入文案
- [ ] 英文语言下传入业务 i18n 占位后不再显示中文「开始日期/结束日期」

Made with [Cursor](https://cursor.com)