### PR TITLE
chore: bump @kne/info-page to ^0.2.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "files": [
     "build"
   ],
@@ -28,7 +28,7 @@
     "@kne/flex-box": "^0.1.2",
     "@kne/form-info": "^0.1.10",
     "@kne/global-context": "^1.3.2",
-    "@kne/info-page": "^0.2.13",
+    "@kne/info-page": "^0.2.14",
     "@kne/is-empty": "^1.1.0",
     "@kne/phone-number-input": "^0.1.7",
     "@kne/react-enum": "^0.1.16",


### PR DESCRIPTION
## Summary
- `@kne/info-page` `^0.2.13` → `^0.2.14`（bordered 内层 Part 去叠边框，保留二级标签）
- `@kne-components/components-core` `0.5.45` → `0.5.46`

## Test plan
- [ ] 合并后确认 Publish workflow 发 npm
- [ ] InfoPage「边框区块」嵌套子 Card：外层有边框、内层无边框、标题为二级标签

Made with [Cursor](https://cursor.com)