### PR TITLE
chore: bump @kne/info-page to ^0.2.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "files": [
     "build"
   ],
@@ -28,7 +28,7 @@
     "@kne/flex-box": "^0.1.2",
     "@kne/form-info": "^0.1.10",
     "@kne/global-context": "^1.3.2",
-    "@kne/info-page": "^0.2.13",
+    "@kne/info-page": "^0.2.15",
     "@kne/is-empty": "^1.1.0",
     "@kne/phone-number-input": "^0.1.7",
     "@kne/react-enum": "^0.1.16",

--- a/src/components/InfoPage/README.md
+++ b/src/components/InfoPage/README.md
@@ -43,96 +43,191 @@ info-page 是一个专为复杂详情展示页面设计的 React 组件库，提
 #### 示例代码
 
 - 基础布局
-- 展示InfoPage容器组件和Part区块组件的基本使用方法
+- 展示 InfoPage / Part / Collapse / Report，可切换灰色背景验证半透明白底
 - _InfoPage(@kne/info-page),(@kne/info-page/dist/index.css),antd(antd)
 
 ```jsx
-const { default: InfoPage } = _InfoPage;
-const { Button, Space, Flex, Tag } = antd;
+const { default: InfoPage, Report, Score } = _InfoPage;
+const { Button, Space, Flex, Tag, Switch, Card } = antd;
+const { useState } = React;
 
 const BaseExample = () => {
+  const [grayBg, setGrayBg] = useState(false);
+
   return (
-    <Flex vertical gap={24}>
-      <Space direction="vertical" size={16}>
-        {/* 基础 Part 使用 */}
-        <InfoPage.Part title="个人信息" subtitle="展示基础 Part 用法">
-          <Space direction="vertical" size={8}>
-            <div><strong>姓名：</strong>张三</div>
-            <div><strong>性别：</strong>男</div>
-            <div><strong>年龄：</strong>28岁</div>
-          </Space>
-        </InfoPage.Part>
+    <Flex vertical gap={16}>
+      <Space align="center">
+        <span>灰色背景</span>
+        <Switch checked={grayBg} onChange={setGrayBg} />
+      </Space>
 
-        {/* 带 extra 的 Part */}
-        <InfoPage.Part 
-          title="联系方式" 
-          subtitle="展示标题和额外操作区"
-          extra={<Button type="primary" size="small">编辑</Button>}
-        >
-          <Space direction="vertical" size={8}>
-            <div><strong>手机：</strong>138-0013-8000</div>
-            <div><strong>邮箱：</strong>zhangsan@example.com</div>
-            <div><strong>地址：</strong>深圳市南山区科技园</div>
-          </Space>
-        </InfoPage.Part>
-
-        {/* 嵌套 Part */}
-        <InfoPage.Part title="工作经历">
-          <p>以下展示了 Part 的嵌套使用：</p>
-          <InfoPage.Part subtitle="现任职位" style={{ background: '#f5f5f5', padding: '12px' }}>
+      <div
+        style={
+          grayBg
+            ? {
+                padding: 24,
+                borderRadius: 8,
+                background: '#f0f0f0'
+              }
+            : undefined
+        }
+      >
+        <InfoPage>
+          <InfoPage.Part title="个人信息" subtitle="展示基础 Part 用法">
             <Space direction="vertical" size={8}>
-              <div><strong>公司：</strong>腾讯科技</div>
-              <div><strong>职位：</strong>高级前端工程师</div>
-              <div><strong>入职时间：</strong>2020年3月</div>
+              <div>
+                <strong>姓名：</strong>张三
+              </div>
+              <div>
+                <strong>性别：</strong>男
+              </div>
+              <div>
+                <strong>年龄：</strong>28岁
+              </div>
             </Space>
           </InfoPage.Part>
-        </InfoPage.Part>
 
-        {/* 带 bordered 的 Part */}
-        <InfoPage.Part title="项目经验" bordered>
-          <Space direction="vertical" size={8}>
-            <div><strong>项目名称：</strong>企业级管理系统</div>
-            <div><strong>技术栈：</strong>React、TypeScript、Ant Design</div>
-            <div><strong>职责：</strong>负责前端架构设计与核心功能开发</div>
-          </Space>
-        </InfoPage.Part>
-
-        {/* Collapse 折叠面板 */}
-        <InfoPage.Collapse
-          items={[
-            { 
-              key: '1', 
-              label: '教育背景', 
-              children: (
-                <Space direction="vertical" size={8}>
-                  <div><strong>学校：</strong>深圳大学</div>
-                  <div><strong>专业：</strong>计算机科学与技术</div>
-                  <div><strong>学历：</strong>本科</div>
-                  <div><strong>毕业时间：</strong>2018年6月</div>
-                </Space>
-              )
-            },
-            { 
-              key: '2', 
-              label: '技能证书', 
-              children: (
-                <Space wrap>
-                  <Tag color="blue">PMP项目管理</Tag>
-                  <Tag color="green">阿里云ACP认证</Tag>
-                  <Tag color="purple">AWS解决方案架构师</Tag>
-                </Space>
-              )
+          <InfoPage.Part
+            title="联系方式"
+            subtitle="展示标题和额外操作区"
+            extra={
+              <Button type="primary" size="small">
+                编辑
+              </Button>
             }
-          ]}
-        />
+          >
+            <Space direction="vertical" size={8}>
+              <div>
+                <strong>手机：</strong>138-0013-8000
+              </div>
+              <div>
+                <strong>邮箱：</strong>zhangsan@example.com
+              </div>
+              <div>
+                <strong>地址：</strong>深圳市南山区科技园
+              </div>
+            </Space>
+          </InfoPage.Part>
 
-        {/* 无标题 Part */}
-        <InfoPage.Part>
-          <div style={{ color: '#666', padding: '12px', background: '#fafafa' }}>
-            <strong>备注：</strong>以上信息仅供示例展示，不代表真实数据
-          </div>
-        </InfoPage.Part>
-      </Space>
+          <InfoPage.Part title="工作经历">
+            <p>以下展示了 Part 的嵌套使用：</p>
+            <InfoPage.Part title="现任职位">
+              <Space direction="vertical" size={8}>
+                <div>
+                  <strong>公司：</strong>腾讯科技
+                </div>
+                <div>
+                  <strong>职位：</strong>高级前端工程师
+                </div>
+                <div>
+                  <strong>入职时间：</strong>2020年3月
+                </div>
+              </Space>
+            </InfoPage.Part>
+          </InfoPage.Part>
+
+          <InfoPage.Part title="项目经验" bordered>
+            <Space direction="vertical" size={16} style={{ width: '100%' }}>
+              <Space direction="vertical" size={8}>
+                <div>
+                  <strong>项目名称：</strong>企业级管理系统
+                </div>
+                <div>
+                  <strong>技术栈：</strong>React、TypeScript、Ant Design
+                </div>
+                <div>
+                  <strong>职责：</strong>负责前端架构设计与核心功能开发
+                </div>
+              </Space>
+              <Card title="内嵌 antd Card" size="small" extra={<Button type="link">详情</Button>}>
+                Part 内放置普通 Card，应保持 antd 默认样式（标题栏边框、内边距、背景等不受 Part 影响）。
+              </Card>
+            </Space>
+          </InfoPage.Part>
+
+          <InfoPage.Collapse
+            items={[
+              {
+                key: '1',
+                label: '教育背景',
+                children: (
+                  <Space direction="vertical" size={8}>
+                    <div>
+                      <strong>学校：</strong>深圳大学
+                    </div>
+                    <div>
+                      <strong>专业：</strong>计算机科学与技术
+                    </div>
+                    <div>
+                      <strong>学历：</strong>本科
+                    </div>
+                    <div>
+                      <strong>毕业时间：</strong>2018年6月
+                    </div>
+                  </Space>
+                )
+              },
+              {
+                key: '2',
+                label: '技能证书',
+                children: (
+                  <Space wrap>
+                    <Tag color="blue">PMP项目管理</Tag>
+                    <Tag color="green">阿里云ACP认证</Tag>
+                    <Tag color="purple">AWS解决方案架构师</Tag>
+                  </Space>
+                )
+              }
+            ]}
+          />
+
+          <Report title="绩效报告" subtitle="半透明白底容器" border={false}>
+            <Space direction="vertical" size={24} style={{ width: '100%' }}>
+              <Report.Result
+                report={{
+                  total: { score: '88.5', label: '综合评分' },
+                  list: [
+                    {
+                      label: '代码质量',
+                      score: '95',
+                      content: '风格规范，注释完整，组件拆分合理。'
+                    },
+                    {
+                      label: '协作沟通',
+                      score: '86',
+                      content: '跨团队沟通顺畅，评审反馈及时。'
+                    }
+                  ]
+                }}
+              />
+              <Report.Part
+                report={{
+                  list: [
+                    {
+                      label: '备注',
+                      hasBgColor: true,
+                      content: (
+                        <ul>
+                          <li>
+                            <Score value={4} total={5} /> 能力达标
+                          </li>
+                          <li className="warning">需继续加强文档沉淀</li>
+                        </ul>
+                      )
+                    }
+                  ]
+                }}
+              />
+            </Space>
+          </Report>
+
+          <InfoPage.Part>
+            <div style={{ color: '#666' }}>
+              <strong>备注：</strong>以上信息仅供示例展示，不代表真实数据
+            </div>
+          </InfoPage.Part>
+        </InfoPage>
+      </div>
     </Flex>
   );
 };
@@ -484,7 +579,7 @@ render(<BaseExample />);
 ```
 
 - 边框区块
-- 展示InfoPage.Part的bordered属性配合CentralContent使用
+- 外层 bordered Part 内嵌子 Card；内层去掉边框，标题保留二级标签样式
 - _InfoPage(@kne/info-page),(@kne/info-page/dist/index.css),antd(antd)
 
 ```jsx
@@ -494,121 +589,119 @@ const { useState } = React;
 
 const BaseExample = () => {
   const [open, setOpen] = useState(false);
-  const baseInfo = (
-    <InfoPage.Part bordered title="员工档案" subtitle="基本信息">
-      <CentralContent
-        type="compact"
-        dataSource={{
-          id: 'RC20240115001',
-          name: '张三',
-          gender: '男',
-          birthday: '1992-03-15',
-          idCard: '440301199203154512',
-          maritalStatus: '已婚',
-          education: '本科',
-          graduationSchool: '深圳大学',
-          major: '计算机科学与技术',
-          entryDate: '2020-03-15',
-          workYears: 4,
-          phone: '138-0013-8000',
-          email: 'zhangsan@tencent.com',
-          address: '广东省深圳市南山区科技园科技中一路腾讯大厦',
-          emergencyContact: '李四',
-          emergencyPhone: '139-0014-9000',
-          emergencyRelation: '配偶'
-        }}
-        col={3}
-        columns={[
-          {
-            name: 'id',
-            title: '员工编号',
-            block: true
-          },
-          {
-            name: 'name',
-            title: '姓名',
-            render: value => (
-              <Space align="center">
-                <Avatar style={{ backgroundColor: '#1890ff' }}>{value[0]}</Avatar>
-                <strong>{value}</strong>
-              </Space>
-            ),
-            span: 10
-          },
-          {
-            name: 'gender',
-            title: '性别'
-          },
-          {
-            name: 'birthday',
-            title: '出生日期',
-            format: 'date'
-          },
-          {
-            name: 'idCard',
-            title: '身份证号',
-            render: value => value.replace(/(\d{6})(\d{8})(\d{4})/, '$1********$3')
-          },
-          {
-            name: 'maritalStatus',
-            title: '婚姻状况'
-          },
-          {
-            name: 'education',
-            title: '学历'
-          },
-          {
-            name: 'graduationSchool',
-            title: '毕业院校'
-          },
-          {
-            name: 'major',
-            title: '专业'
-          },
-          {
-            name: 'entryDate',
-            title: '入职日期',
-            format: 'date'
-          },
-          {
-            name: 'workYears',
-            title: '工作年限',
-            format: 'number-suffix:年'
-          },
-          {
-            name: 'phone',
-            title: '联系电话',
-            render: value => value.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
-          },
-          {
-            name: 'email',
-            title: '电子邮箱'
-          },
-          {
-            name: 'address',
-            title: '家庭住址',
-            block: true
-          },
-          {
-            name: 'emergencyContact',
-            title: '紧急联系人'
-          },
-          {
-            name: 'emergencyPhone',
-            title: '紧急联系电话',
-            render: value => value.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
-          },
-          {
-            name: 'emergencyRelation',
-            title: '与本人关系'
-          }
-        ]}
-      />
-    </InfoPage.Part>
-  );
-  return (
-    <InfoPage>
-      {baseInfo}
+  const employeeCard = (
+    <InfoPage.Part bordered title="员工档案" subtitle="外层 bordered，内层子 Card 无边框，标题为二级标签样式">
+      <InfoPage.Part bordered title="基本信息">
+        <CentralContent
+          type="compact"
+          dataSource={{
+            id: 'RC20240115001',
+            name: '张三',
+            gender: '男',
+            birthday: '1992-03-15',
+            idCard: '440301199203154512',
+            maritalStatus: '已婚',
+            education: '本科',
+            graduationSchool: '深圳大学',
+            major: '计算机科学与技术',
+            entryDate: '2020-03-15',
+            workYears: 4,
+            phone: '138-0013-8000',
+            email: 'zhangsan@tencent.com',
+            address: '广东省深圳市南山区科技园科技中一路腾讯大厦',
+            emergencyContact: '李四',
+            emergencyPhone: '139-0014-9000',
+            emergencyRelation: '配偶'
+          }}
+          col={3}
+          columns={[
+            {
+              name: 'id',
+              title: '员工编号',
+              block: true
+            },
+            {
+              name: 'name',
+              title: '姓名',
+              render: value => (
+                <Space align="center">
+                  <Avatar style={{ backgroundColor: '#1890ff' }}>{value[0]}</Avatar>
+                  <strong>{value}</strong>
+                </Space>
+              ),
+              span: 10
+            },
+            {
+              name: 'gender',
+              title: '性别'
+            },
+            {
+              name: 'birthday',
+              title: '出生日期',
+              format: 'date'
+            },
+            {
+              name: 'idCard',
+              title: '身份证号',
+              render: value => value.replace(/(\d{6})(\d{8})(\d{4})/, '$1********$3')
+            },
+            {
+              name: 'maritalStatus',
+              title: '婚姻状况'
+            },
+            {
+              name: 'education',
+              title: '学历'
+            },
+            {
+              name: 'graduationSchool',
+              title: '毕业院校'
+            },
+            {
+              name: 'major',
+              title: '专业'
+            },
+            {
+              name: 'entryDate',
+              title: '入职日期',
+              format: 'date'
+            },
+            {
+              name: 'workYears',
+              title: '工作年限',
+              format: 'number-suffix:年'
+            },
+            {
+              name: 'phone',
+              title: '联系电话',
+              render: value => value.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
+            },
+            {
+              name: 'email',
+              title: '电子邮箱'
+            },
+            {
+              name: 'address',
+              title: '家庭住址',
+              block: true
+            },
+            {
+              name: 'emergencyContact',
+              title: '紧急联系人'
+            },
+            {
+              name: 'emergencyPhone',
+              title: '紧急联系电话',
+              render: value => value.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3')
+            },
+            {
+              name: 'emergencyRelation',
+              title: '与本人关系'
+            }
+          ]}
+        />
+      </InfoPage.Part>
+
       <InfoPage.Part bordered title="工作信息" subtitle="部门与职位">
         <CentralContent
           type="compact"
@@ -674,7 +767,11 @@ const BaseExample = () => {
           ]}
         />
       </InfoPage.Part>
-
+    </InfoPage.Part>
+  );
+  return (
+    <InfoPage>
+      {employeeCard}
       <InfoPage.Part bordered title="放在Modal中">
         <Button
           onClick={() => {
@@ -682,7 +779,9 @@ const BaseExample = () => {
           }}>
           打开Modal
         </Button>
-        <Modal title="员工档案" open={open} onCancel={()=>setOpen(false)}>{baseInfo}</Modal>
+        <Modal title="员工档案" open={open} onCancel={() => setOpen(false)}>
+          {employeeCard}
+        </Modal>
       </InfoPage.Part>
     </InfoPage>
   );


### PR DESCRIPTION
## Summary
- `@kne/info-page` `^0.2.13` → `^0.2.15`（0.2.14 内层 bordered 去叠边框；0.2.15 容器透明/半透明白底）
- `@kne-components/components-core` `0.5.45` → `0.5.46`
- 同步 InfoPage 文档示例

本 PR 覆盖未合并的 #682（仅升到 0.2.14）。

## Test plan
- [ ] 合并后确认 Publish workflow 发 npm `@kne-components/components-core@0.5.46`
- [ ] InfoPage「基础布局」灰色背景：半透明白底
- [ ] InfoPage「边框区块」嵌套子 Card：外层有边框、内层无叠边框、标题为二级标签


Made with [Cursor](https://cursor.com)