### PR TITLE
fix: Global 订阅 themeToken，弹窗主按钮跟随主题色

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.46",
+  "version": "0.5.47",
   "files": [
     "build"
   ],

--- a/src/components/Global/index.js
+++ b/src/components/Global/index.js
@@ -206,21 +206,23 @@ export const GlobalProvider = ({
     }, get(preset, "global"))}>
         <GlobalResponsiveScope>
             <GlobalValue globalKey="locale">{({value: locale}) => {
-            return <ConfigProvider
-                loader={loadAntdLocale}
-                params={{locale}}
-                themeToken={themeToken}
-            >
-                <App message={{top: 100}}>
-                    <AppDrawer>
-                        {typeof init === "function" ? (<Fetch
-                            loader={() => init()}
-                            render={() => children}
-                        />) : (children)}
-                    </AppDrawer>
-                </App>
-                <GlobalFontLoader/>
-            </ConfigProvider>;
+            return <GlobalValue globalKey="themeToken">{({value: liveThemeToken}) => (
+                <ConfigProvider
+                    loader={loadAntdLocale}
+                    params={{locale}}
+                    themeToken={liveThemeToken || themeToken}
+                >
+                    <App message={{top: 100}}>
+                        <AppDrawer>
+                            {typeof init === "function" ? (<Fetch
+                                loader={() => init()}
+                                render={() => children}
+                            />) : (children)}
+                        </AppDrawer>
+                    </App>
+                    <GlobalFontLoader/>
+                </ConfigProvider>
+            )}</GlobalValue>;
         }}</GlobalValue>
         </GlobalResponsiveScope>
     </GlobalContext>);


### PR DESCRIPTION
## Summary
- GlobalProvider 的根 ConfigProvider 改为订阅 context 中的 `themeToken`，不再使用创建时冻结的 props。
- `SetGlobal` 写入租户色后，`<App>` 及 `App.useApp().modal.info()` 弹窗主按钮会跟随主题色。
- 版本：0.5.46 → 0.5.47

## Test plan
- [ ] 业务仓将 `components-core` remote 指到本地 `http://localhost:3001`
- [ ] `npm start` 启动本仓后刷新业务页，打开 FormModal / 任意确认弹窗
- [ ] 主按钮（Save / 确定）颜色与租户 `themeColor` 一致，不再停留在默认 `#4183F0`
- [ ] 页面内非弹窗 primary 按钮主题色不受影响


Made with [Cursor](https://cursor.com)