### PR TITLE
chore: bump @kne/form-info to ^0.1.23 (0.5.48)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kne-components/components-core",
-  "version": "0.5.47",
+  "version": "0.5.48",
   "files": [
     "build"
   ],
@@ -26,7 +26,7 @@
     "@kne/create-deferred": "^0.1.1",
     "@kne/ensure-slash": "^0.1.0",
     "@kne/flex-box": "^0.1.2",
-    "@kne/form-info": "^0.1.10",
+    "@kne/form-info": "^0.1.23",
     "@kne/global-context": "^1.3.2",
     "@kne/info-page": "^0.2.15",
     "@kne/is-empty": "^1.1.0",


### PR DESCRIPTION
## Summary
- 将 `@kne/form-info` 从 `^0.1.10` 升级到 `^0.1.23`（FormModal `renderModal` 透传 `formProps` / `saveText` / `autoClose`）
- `@kne-components/components-core` version `0.5.47` → `0.5.48`

## Test plan
- [ ] 合并后确认 Publish Npm Package 发布 `@kne-components/components-core@0.5.48`
- [ ] FormInfo / FormModal 默认弹窗提交、取消正常


Made with [Cursor](https://cursor.com)